### PR TITLE
change card border, bgc and shelter details in pet show

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -15,6 +15,8 @@
 
 .card-img-top {
   object-fit: cover;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
 }
 
 .cards {
@@ -73,6 +75,11 @@
 
 .card > img {
   height: 10rem;
+}
+
+.card {
+  background-color: #f6f6eed8;
+  border-radius: 5px;
 }
 
 .card:hover {

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -54,8 +54,8 @@
 <ul>
 <li>Name: <%= link_to @pet.shelter.name, shelter_path(@pet.shelter) %></li>
 <li>Address: <%= @pet.shelter.address %></li>
-<li><a href="tel:<%= @pet.shelter.contact %>">Contact: <%= @pet.shelter.contact %></a></li>
-<li><a href="mailto:<%= @pet.shelter.email %>">Email: <%= @pet.shelter.email %></a></p></li>
+<li><span>Contact: </span><a href="tel:<%= @pet.shelter.contact %>"><%= @pet.shelter.contact %></a></li>
+<li><span>Email: </span><a href="mailto:<%= @pet.shelter.email %>"><%= @pet.shelter.email %></a></p></li>
 
 </ul>
 </div>


### PR DESCRIPTION
shelter contact and email details in pet show was a whole link previously. changed it to only be the actual contact number and email.